### PR TITLE
Add missing settings.gradle file

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include 'app'


### PR DESCRIPTION
As per http://stackoverflow.com/questions/41506453/how-to-run-gradlew-test
the test task is unavailable because gradle doesn't know app is
part of the build.  Here gradle was compiling nothing from the root
app as the build task didn't exist on the project